### PR TITLE
docs: use lowercase marketplace name to fix macOS case-sensitive rename bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,13 @@ Comprehensive paid advertising audit and optimization skill for Claude Code. Cov
 Add the marketplace and install in Claude Code:
 
 ```shell
-/plugin marketplace add agricidaniel/claude-ads
+/plugin marketplace add AgriciDaniel/claude-ads
 /plugin install claude-ads@agricidaniel-claude-ads
 ```
 
 This registers claude-ads as a native plugin with auto-updates, namespace isolation, and proper version tracking.
 
-> **macOS workaround:** Use lowercase `agricidaniel/claude-ads` (not `AgriciDaniel/claude-ads`). Mixed-case names trigger a rename failure on case-insensitive macOS filesystems ([#17](https://github.com/AgriciDaniel/claude-ads/issues/17)). The lowercase form works identically.
+> **macOS workaround:** Use lowercase `agricidaniel/claude-ads` (not `AgriciDaniel/claude-ads`). Mixed-case names trigger a rename failure on case-insensitive macOS filesystems.
 
 ### One-Command Install (Unix/macOS/Linux)
 

--- a/README.md
+++ b/README.md
@@ -35,11 +35,13 @@ Comprehensive paid advertising audit and optimization skill for Claude Code. Cov
 Add the marketplace and install in Claude Code:
 
 ```shell
-/plugin marketplace add AgriciDaniel/claude-ads
+/plugin marketplace add agricidaniel/claude-ads
 /plugin install claude-ads@agricidaniel-claude-ads
 ```
 
 This registers claude-ads as a native plugin with auto-updates, namespace isolation, and proper version tracking.
+
+> **macOS workaround:** Use lowercase `agricidaniel/claude-ads` (not `AgriciDaniel/claude-ads`). Mixed-case names trigger a rename failure on case-insensitive macOS filesystems ([#17](https://github.com/AgriciDaniel/claude-ads/issues/17)). The lowercase form works identically.
 
 ### One-Command Install (Unix/macOS/Linux)
 


### PR DESCRIPTION
## Summary

- Changes `/plugin marketplace add AgriciDaniel/claude-ads` → `agricidaniel/claude-ads` in README
- Adds inline note explaining the macOS workaround and linking to #17

## Root cause

Claude Code CLI derives a temp directory from the GitHub path (`AgriciDaniel-claude-ads`), then renames it to the lowercase form from `marketplace.json` (`agricidaniel-claude-ads`). On macOS default APFS (case-insensitive), both names resolve to the same inode — the rename fails with `ENOENT`. Using lowercase input avoids the rename entirely.

## Test plan

- [ ] Run `/plugin marketplace add agricidaniel/claude-ads` on macOS — succeeds
- [ ] Run `/plugin marketplace add AgriciDaniel/claude-ads` on macOS — still fails (root fix needed in Claude Code CLI)

Closes #17