### PR TITLE
fix: remove --break-system-packages silent fallback in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -69,11 +69,14 @@ main() {
     if command -v pip3 >/dev/null 2>&1 || command -v pip >/dev/null 2>&1; then
         PIP_CMD="pip3"
         command -v pip3 >/dev/null 2>&1 || PIP_CMD="pip"
-        ${PIP_CMD} install -q -r "${SKILL_DIR}/requirements.txt" 2>/dev/null \
-            || { echo "  ⚠ Standard pip install failed, trying --break-system-packages..." >&2; \
-                 ${PIP_CMD} install --break-system-packages -q -r "${SKILL_DIR}/requirements.txt" 2>/dev/null; } \
-            && echo "  ✓ Python dependencies installed" \
-            || echo "  ⚠ pip install failed. Run manually: pip3 install -r ${SKILL_DIR}/requirements.txt"
+        if ${PIP_CMD} install -q -r "${SKILL_DIR}/requirements.txt" 2>/dev/null; then
+            echo "  ✓ Python dependencies installed"
+        else
+            echo "  ⚠ pip install failed. To install in a virtual environment:" >&2
+            echo "    python3 -m venv ~/.venv && source ~/.venv/bin/activate" >&2
+            echo "    pip install -r ${SKILL_DIR}/requirements.txt" >&2
+            echo "  Or install globally (use with care): pip3 install -r ${SKILL_DIR}/requirements.txt" >&2
+        fi
     else
         echo "  ⚠ pip not found. Install deps manually: pip3 install -r ${SKILL_DIR}/requirements.txt"
     fi


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

`install.sh` lines 70–76 silently fall back to `pip install --break-system-packages` when the standard `pip install` fails. This flag bypasses pip's protection for system-managed Python environments, which can corrupt system packages without the user's knowledge or consent.

On modern Linux distros (Debian 12+, Ubuntu 23.04+, Fedora 38+), system Python is externally managed. The `--break-system-packages` flag exists for explicit opt-in, not as a transparent fallback.

## Fix

Replace the silent fallback with a clear failure message and virtual environment guidance, consistent with the script's existing error-surfacing pattern (e.g. the `pip not found` branch on line 78 already does this correctly).

## Before

```bash
${PIP_CMD} install -q -r "${SKILL_DIR}/requirements.txt" 2>/dev/null \
    || { echo "  ⚠ Standard pip install failed, trying --break-system-packages..." >&2; \
         ${PIP_CMD} install --break-system-packages -q -r "${SKILL_DIR}/requirements.txt" 2>/dev/null; } \
    && echo "  ✓ Python dependencies installed" \
    || echo "  ⚠ pip install failed. ..."
```

## After

```bash
if ${PIP_CMD} install -q -r "${SKILL_DIR}/requirements.txt" 2>/dev/null; then
    echo "  ✓ Python dependencies installed"
else
    echo "  ⚠ pip install failed. To install in a virtual environment:" >&2
    echo "    python3 -m venv ~/.venv && source ~/.venv/bin/activate" >&2
    echo "    pip install -r ${SKILL_DIR}/requirements.txt" >&2
    echo "  Or install globally (use with care): pip3 install -r ${SKILL_DIR}/requirements.txt" >&2
fi
```

Users who need the global install can still do it explicitly — the failure message tells them how.