### PR TITLE
fix: replace curl-pipe-sh guidance with plugin install command in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -84,7 +84,7 @@ main() {
         echo "  ✓ banana-claude detected (image generation ready)"
     else
         echo "  ⚠ banana-claude not installed. Image generation (/ads generate, /ads photoshoot) requires it."
-        echo "    Install: curl -fsSL https://raw.githubusercontent.com/AgriciDaniel/banana-claude/main/install.sh | bash"
+        echo "    Install: claude plugin install banana-claude@AgriciDaniel --scope user"
         echo "    Then run: /banana setup (to configure API key)"
     fi
 


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

`install.sh` line 87 instructs users to install banana-claude by piping a remote shell script directly to bash:

```bash
echo "    Install: curl -fsSL https://raw.githubusercontent.com/AgriciDaniel/banana-claude/main/install.sh | bash"
```

The `curl ... | bash` pattern (curl-pipe-sh) executes unauthenticated remote code without allowing the user to inspect the script first. If the remote URL is compromised, users have no way to detect it.

Claude Code ships a native plugin install command that uses the plugin registry for verification. That's the appropriate installation path for Claude Code plugins.

## Fix

Replace the curl-pipe-sh suggestion with the plugin registry command:

```bash
echo "    Install: claude plugin install banana-claude@AgriciDaniel --scope user"
```

This is a single-line change with no behavioral impact on the rest of the installer.