### PR TITLE
fix(security): validate --output-dir against path traversal (#30)

### DIFF
--- a/scripts/generate_image.py
+++ b/scripts/generate_image.py
@@ -93,6 +93,30 @@ def _sanitize_error(err: Exception) -> str:
     )
 
 
+def _validate_output_dir(output_dir: str) -> Path:
+    """Resolve output_dir and refuse paths that escape the allowed base.
+
+    The base is the current working directory by default. Set the
+    CLAUDE_ADS_OUTPUT_BASE env var to allow writing under a different root
+    (e.g. when an orchestrator legitimately needs an absolute path outside
+    CWD). The script-level filename sanitisation in run_batch already strips
+    path components from job filenames; this helper closes the matching gap
+    on --output-dir itself.
+
+    See: https://github.com/AgriciDaniel/claude-ads/issues/30
+    """
+    base = Path(os.environ.get("CLAUDE_ADS_OUTPUT_BASE", os.getcwd())).resolve()
+    resolved = Path(output_dir).resolve()
+    try:
+        resolved.relative_to(base)
+    except ValueError:
+        raise ValueError(
+            f"output_dir {output_dir!r} resolves outside allowed base {str(base)!r}. "
+            f"Set CLAUDE_ADS_OUTPUT_BASE to override."
+        )
+    return resolved
+
+
 def _actual_dimensions(image_bytes: bytes) -> tuple[int, int] | None:
     """
     Extract actual width/height from PNG or JPEG header without PIL.
@@ -425,7 +449,12 @@ def run_batch(batch_file: str, output_dir: str, provider: str, model: str | None
         print(f"Error: Batch file contains {len(jobs)} jobs, max is {MAX_BATCH_SIZE}", file=sys.stderr)
         sys.exit(1)
 
-    Path(output_dir).mkdir(parents=True, exist_ok=True)
+    try:
+        safe_output_dir = _validate_output_dir(output_dir)
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+    safe_output_dir.mkdir(parents=True, exist_ok=True)
     results = []
 
     for i, job in enumerate(jobs):
@@ -434,7 +463,7 @@ def run_batch(batch_file: str, output_dir: str, provider: str, model: str | None
         output_name = job.get("output", f"image_{i:03d}.png")
         # Security: strip path components to prevent directory traversal
         output_name = Path(output_name).name
-        output_path = str(Path(output_dir) / output_name)
+        output_path = str(safe_output_dir / output_name)
         reference_image = job.get("reference_image", None)
         if reference_image and Path(reference_image).suffix.lower() not in _ALLOWED_IMAGE_EXTENSIONS:
             print(f"  ⚠ Skipping invalid reference image: {reference_image}", file=sys.stderr)

--- a/tests/test_output_dir_validation.py
+++ b/tests/test_output_dir_validation.py
@@ -1,0 +1,75 @@
+"""
+Regression tests for issue #30: path traversal via --output-dir in batch mode.
+
+https://github.com/AgriciDaniel/claude-ads/issues/30
+
+scripts/generate_image.py sanitises filenames inside batch jobs (Path(...).name)
+but did not validate the --output-dir argument itself, so a path like
+"/tmp/../../etc/cron.d" resolved outside the working directory would be
+created and written to.
+
+These tests pin the behaviour of the new _validate_output_dir() helper:
+  - reject paths that resolve outside the working directory
+  - allow paths that resolve inside it
+  - honour the CLAUDE_ADS_OUTPUT_BASE env var as an explicit override
+
+Run with:
+    python -m unittest tests.test_output_dir_validation
+"""
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from generate_image import _validate_output_dir  # noqa: E402
+
+
+class ValidateOutputDirTest(unittest.TestCase):
+    def test_rejects_relative_traversal(self):
+        with self.assertRaises(ValueError):
+            _validate_output_dir("../../etc")
+
+    def test_rejects_traversal_with_absolute_prefix(self):
+        # Reporter's exact example from issue #30
+        with self.assertRaises(ValueError):
+            _validate_output_dir("/tmp/../../etc/cron.d")
+
+    def test_rejects_absolute_outside_cwd(self):
+        with self.assertRaises(ValueError):
+            _validate_output_dir("/etc/cron.d")
+
+    def test_allows_relative_within_cwd(self):
+        result = _validate_output_dir("./ad-assets")
+        self.assertTrue(
+            str(result).startswith(str(Path.cwd().resolve())),
+            f"Expected {result} to be under {Path.cwd().resolve()}",
+        )
+
+    def test_allows_dot(self):
+        result = _validate_output_dir(".")
+        self.assertEqual(result, Path(".").resolve())
+
+    def test_env_var_overrides_base(self):
+        with tempfile.TemporaryDirectory() as base:
+            with mock.patch.dict(os.environ, {"CLAUDE_ADS_OUTPUT_BASE": base}):
+                target = str(Path(base) / "ads")
+                result = _validate_output_dir(target)
+                self.assertTrue(
+                    str(result).startswith(str(Path(base).resolve())),
+                    f"Expected {result} under override base {Path(base).resolve()}",
+                )
+
+    def test_env_var_does_not_allow_escape_above_override(self):
+        with tempfile.TemporaryDirectory() as base:
+            with mock.patch.dict(os.environ, {"CLAUDE_ADS_OUTPUT_BASE": base}):
+                with self.assertRaises(ValueError):
+                    _validate_output_dir(str(Path(base) / ".." / "escaped"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary                                              
                                                  
  `run_batch()` strips path components from per-job       
  filenames but does not validate `--output-dir` itself,  
  so a path that resolves outside CWD (e.g. 
  `/tmp/../../etc/cron.d`) gets created and written into. 
                                                        
  This is defense in depth, not RCE — exploitation        
  requires the script to be invoked by an orchestrator  
  forwarding user-influenced arguments (e.g. an agent or  
  wrapper). A direct shell user can already write wherever
   their account allows.                                  
                                                          
  ## Type of Change                                     
  - [x] Bug fix
                                                          
  ## What this PR does                   
  - Adds `_validate_output_dir(output_dir)` that resolves 
  the path and rejects anything outside the working     
  directory.                            
  - `CLAUDE_ADS_OUTPUT_BASE` env var as the escape hatch
  when an absolute path outside CWD is intentional.
  - Uses `Path.resolve()` + `relative_to()` (matches your
  option 2 in the issue).                   
  - `run_batch` swaps `Path(output_dir)` for the validated
   path; nothing else in the function is touched.
                                                          
  ## Tests                                              
                                                          
  7 regression tests in                                   
  `tests/test_output_dir_validation.py` using stdlib
  `unittest` — no new deps. Covers the reporter's exact   
  reproduction, relative traversal, absolute paths outside
   CWD, dot-path acceptance, the env override, and the env
   override not allowing escape above the configured base.
                                                          
  CI doesn't run tests today (only `py_compile` /       
  pip-audit). Happy to wire `python -m unittest discover` 
  into CI in a follow-up.                   
                                                          
  ## Checklist                                          
  - [x] No credentials or API keys in the diff
  - [x] Backward compatible (existing relative output dirs
   keep working)                    
  - [N/A] SKILL.md / reference files (none touched)       
  - [N/A] Shell scripts (none touched)  
  - [N/A] Tested against a sample ad account (no platform 
  code touched)                                         
                                            
  ## Reproducer (pre-fix)               
                                                          
      python scripts/generate_image.py --batch
  prompts.json --output-dir /tmp/../../etc/cron.d         
      # Pre-fix: creates /etc/cron.d and writes images  
  there.                                                  
      # Post-fix: errors out with clear message and exits
  1.                                                      
                                                        
  Closes #30                    