### PR TITLE
fix: update sub-skill count from 17 to 19 in SKILL.md

### DIFF
--- a/ads/SKILL.md
+++ b/ads/SKILL.md
@@ -8,7 +8,7 @@ license: MIT
 # Ads: Multi-Platform Paid Advertising Audit & Optimization
 
 Comprehensive ad account analysis across all major platforms (Google, Meta,
-LinkedIn, TikTok, Microsoft). Orchestrates 17 specialized sub-skills and
+LinkedIn, TikTok, Microsoft). Orchestrates 19 specialized sub-skills and
 10 agents (6 audit + 4 creative).
 
 ## Quick Reference


### PR DESCRIPTION
## Summary

- The orchestrator description in `ads/SKILL.md` referenced 17 sub-skills
- `ads-math` and `ads-test` were added in v1.4.0, bringing the total to 19
- The README already reflects 19 correctly - this syncs the SKILL.md description

## Test plan

- [ ] Verify `ads/SKILL.md` now reads '19 specialized sub-skills'
- [ ] Confirm count matches the 19 skill folders under `skills/`

 Generated with [Claude Code](https://claude.ai/claude-code)