### PR TITLE
fix(install): point REPO_URL at this repo + unmute clone errors

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -23,7 +23,7 @@ set -euo pipefail
 # possible via --target=...). Custom --skill-dir paths are validated against
 # `;&|$()<>` ` `, leading dashes, `..` segments, and UNC-style paths.
 
-REPO_URL="https://github.com/AI-Marketing-Hub/claude-ads"
+REPO_URL="https://github.com/AgriciDaniel/claude-ads"
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Target whitelist + path mapping
@@ -221,7 +221,7 @@ main() {
     trap 'rm -rf "${TEMP_DIR}"' EXIT
 
     echo "↓ Downloading Claude Ads..."
-    git clone --depth 1 "${REPO_URL}" "${TEMP_DIR}/claude-ads" 2>/dev/null
+    git clone --depth 1 "${REPO_URL}" "${TEMP_DIR}/claude-ads"
 
     # Copy main skill + references
     echo "→ Installing skill files..."


### PR DESCRIPTION
## Summary
- `install.sh`'s `REPO_URL` still pointed at `https://github.com/AI-Marketing-Hub/claude-ads`, which no longer resolves. Anyone running `bash install.sh` (including via the documented "clone + bash install.sh" pattern) currently hits a silent `exit 128`.
- Updated `REPO_URL` to point at `https://github.com/AgriciDaniel/claude-ads`.
- Removed `2>/dev/null` on the clone — that's what hid the underlying `remote: Repository not found.` message and made the failure look like a generic git error with no explanation. Errors on this line are always actionable and belong on stderr.

## Reproduction (before this PR)
```
$ git clone --depth 1 https://github.com/AgriciDaniel/claude-ads /tmp/claude-ads && cd /tmp/claude-ads && bash install.sh
...
✓ Git detected
↓ Downloading Claude Ads...
$ echo $?
128
```
With `2>/dev/null` removed, the real error becomes visible:
```
remote: Repository not found.
fatal: repository 'https://github.com/AI-Marketing-Hub/claude-ads/' not found
```

## After this PR
Verified end-to-end in a clean `debian:bookworm-slim` container — `install.sh` completes with exit 0 and lays down all 22 sub-skills and 10 agents.

## Test plan
- [x] `bash install.sh` succeeds in a fresh container with only `git` + `ca-certificates`
- [x] Diff is two lines, both in `install.sh`; no behavior change to any other target/path