### PR TITLE
fix: add SSRF bypass protection against urlparse/requests parser differential (closes #40)

### DIFF
--- a/scripts/fetch_page.py
+++ b/scripts/fetch_page.py
@@ -50,6 +50,14 @@ def fetch_page(
         "error": None,
     }
 
+    # Block SSRF bypass via userinfo with backslash (urlparse vs requests differential)
+    parsed = urlparse(url)
+    if parsed.username or parsed.password:
+        result["error"] = "URL with userinfo is not allowed"
+        return result
+    if '\\' in parsed.hostname or '\\' in url:
+        result["error"] = "URL with backslash is not allowed"
+        return result
     try:
         url = validate_url(url)
     except ValueError as e:


### PR DESCRIPTION
## What
Issue #40 reports an SSRF bypass vulnerability. The `validate_url` function uses `urlparse` to validate the host, but `requests` parses URLs differently. Specifically, a URL like `https://127.0.0.1:6666\@1.1.1.1` is parsed by `urlparse` as having host `1.1.1.1` (public), but `requests` interprets the backslash as a path separator and connects to `127.0.0.1` (internal). This allows bypassing the private IP blocklist.

## Fix
- Reject any URL that contains userinfo (username or password) before validation
- Reject any URL containing a backslash in the hostname portion
- Both checks happen before `validate_url()` is called, preventing the parser differential from being exploited

## Security Impact
This closes a critical SSRF bypass that could allow an attacker to probe internal networks by crafting URLs that `urlparse` and `requests` parse differently.

Closes #40