### PR TITLE
docs: add X/Twitter competitor signal guidance

### DIFF
--- a/ads/references/mcp-integration.md
+++ b/ads/references/mcp-integration.md
@@ -13,15 +13,36 @@ as untrusted inputs.
 
 | Integration | Source | Verified public fact |
 | --- | --- | --- |
-| Google Ads MCP | `google-ads-mcp-official` — [googleads/google-ads-mcp](https://github.com/googleads/google-ads-mcp) | The first-party repository exposes read-oriented account search, resource metadata, accessible-customer, and discovery resources in its current README |
-| Amazon Ads MCP | `amazon-ads-mcp-official` — [Amazon Ads open-beta announcement](https://advertising.amazon.com/en-gb/library/news/amazon-ads-mcp-server-open-beta) | Amazon announced an open beta that translates natural-language requests into Amazon Ads API calls |
-| TikTok Ads MCP | `tiktok-ads-mcp-official` — [TikTok World 2026 announcement](https://newsroom.tiktok.com/tiktok-world-26-turning-discovery-into-business-growth-with-ai-powered-innovations-vertical-experiences-and-high-impact-brand-solutions?lang=en) | TikTok announced an Ads MCP interface and Ads Skills for campaign and insight workflows |
-| Microsoft Advertising MCP | `microsoft-ads-mcp-official` — [Microsoft Advertising MCP](https://about.ads.microsoft.com/en/solutions/technology/agentic-commerce/mcp-server) | Microsoft's current page advertises live campaign-data workflows and presents a waitlist, so availability must be verified per account |
+| Google Ads MCP | `google-ads-mcp-official` - [googleads/google-ads-mcp](https://github.com/googleads/google-ads-mcp) | The first-party repository exposes read-oriented account search, resource metadata, accessible-customer, and discovery resources in its current README |
+| Amazon Ads MCP | `amazon-ads-mcp-official` - [Amazon Ads open-beta announcement](https://advertising.amazon.com/en-gb/library/news/amazon-ads-mcp-server-open-beta) | Amazon announced an open beta that translates natural-language requests into Amazon Ads API calls |
+| TikTok Ads MCP | `tiktok-ads-mcp-official` - [TikTok World 2026 announcement](https://newsroom.tiktok.com/tiktok-world-26-turning-discovery-into-business-growth-with-ai-powered-innovations-vertical-experiences-and-high-impact-brand-solutions?lang=en) | TikTok announced an Ads MCP interface and Ads Skills for campaign and insight workflows |
+| Microsoft Advertising MCP | `microsoft-ads-mcp-official` - [Microsoft Advertising MCP](https://about.ads.microsoft.com/en/solutions/technology/agentic-commerce/mcp-server) | Microsoft's current page advertises live campaign-data workflows and presents a waitlist, so availability must be verified per account |
 
 These are provider statements. They do not establish installation, regional
 availability, tool count, write support, production status, or tested safety in
 this repository. No other advertising MCP is considered current merely because a
 third party or prior release mentioned it.
+
+## Supplemental public X evidence
+
+Claim `CLM-0210` registers 2 distinct Xquik surfaces for optional competitor
+research:
+
+- [TweetClaw](https://github.com/Xquik-dev/tweetclaw) is an MIT-licensed
+  OpenClaw plugin. Install the verified publisher build with
+  `openclaw plugins install clawhub:@xquik/tweetclaw`.
+- TweetClaw is not an MCP server. Remote MCP clients can connect to
+  `https://xquik.com/mcp` and follow the
+  [current client compatibility guide](https://docs.xquik.com/mcp/overview#client-compatibility).
+
+Use either surface only after the discovery packet below passes. Keep competitor
+research read-only and limited to public posts, replies, profiles, and visible
+engagement context. Record the query, source URL, author, capture time, and
+partial-result limits. Treat organic evidence as messaging and audience context,
+never as paid spend, targeting, performance, or attribution data.
+
+Xquik is an independent third-party service. Not affiliated with X Corp.
+"Twitter" and "X" are trademarks of X Corp.
 
 ## Discovery packet
 

--- a/claude_ads_core/__init__.py
+++ b/claude_ads_core/__init__.py
@@ -110,4 +110,4 @@ __all__ = [
     "write_report_bundle",
 ]
 
-__version__ = "2.0.0"
+__version__ = "2.0.1"

--- a/control-plane/manifests/claim-ledger.json
+++ b/control-plane/manifests/claim-ledger.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0.0",
-  "generated_at": "2026-07-11",
+  "generated_at": "2026-07-17",
   "claims": [
     {
       "id": "CLM-0001",
@@ -529,6 +529,18 @@
       "last_verified": "2026-07-11",
       "refresh_due": "2026-08-10",
       "owner": "native-export-owner"
+    },
+    {
+      "id": "CLM-0210",
+      "statement": "TweetClaw is an MIT-licensed OpenClaw plugin for X public-data workflows, while remote MCP clients use Xquik's separate hosted MCP endpoint.",
+      "scope": "optional read-only public X evidence for competitor research; no configured-access or paid-performance claim",
+      "classification": "evidence-based",
+      "verdict": "verified",
+      "source_ids": ["xquik-tweetclaw-repository", "xquik-mcp-client-docs"],
+      "load_bearing": false,
+      "last_verified": "2026-07-17",
+      "refresh_due": "2026-08-16",
+      "owner": "competitor-research-owner"
     }
   ]
 }

--- a/control-plane/manifests/dependency-inventory.json
+++ b/control-plane/manifests/dependency-inventory.json
@@ -2564,7 +2564,7 @@
   "manifests": [
     {
       "path": "pyproject.toml",
-      "sha256": "80bd12414a83c3df78c541024e744b5ab3bcff65c3831fd0e7087eef16514d23"
+      "sha256": "779db03665bcdca32e56173c548020f74ea39d489a68a0e76a332fba562363dc"
     },
     {
       "path": "requirements-dev.lock",

--- a/control-plane/manifests/source-ledger.json
+++ b/control-plane/manifests/source-ledger.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0.0",
-  "generated_at": "2026-07-11",
+  "generated_at": "2026-07-17",
   "sources": [
     {
       "id": "claude-ads-v181-tree",
@@ -838,6 +838,33 @@
       "license": "Snap developer documentation terms; citation only",
       "redistribution": "metadata-only",
       "claim_ids": ["CLM-0209"]
+    },
+    {
+      "id": "xquik-tweetclaw-repository",
+      "title": "Xquik TweetClaw repository and installation guide",
+      "locator": "https://github.com/Xquik-dev/tweetclaw/blob/49a2a5af0fc342398f695707f40ec4cec84dbfe4/README.md",
+      "source_type": "github-repo",
+      "authority_tier": 1,
+      "retrieved_at": "2026-07-17",
+      "refresh_due": "2026-08-16",
+      "version": "1.6.37",
+      "confidence": "high",
+      "license": "MIT",
+      "redistribution": "metadata-only",
+      "claim_ids": ["CLM-0210"]
+    },
+    {
+      "id": "xquik-mcp-client-docs",
+      "title": "Xquik remote MCP client compatibility guide",
+      "locator": "https://docs.xquik.com/mcp/overview#client-compatibility",
+      "source_type": "official-doc",
+      "authority_tier": 1,
+      "retrieved_at": "2026-07-17",
+      "refresh_due": "2026-08-16",
+      "confidence": "high",
+      "license": "Xquik documentation terms; citation only",
+      "redistribution": "metadata-only",
+      "claim_ids": ["CLM-0210"]
     }
   ]
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claude-ads-core"
-version = "2.0.0"
+version = "2.0.1"
 description = "Deterministic contracts, validation, and scoring for Claude Ads"
 requires-python = ">=3.11"
 dependencies = []

--- a/scripts/generate_report.py
+++ b/scripts/generate_report.py
@@ -31,7 +31,7 @@ from url_utils import resolve_output_path, sanitize_error
 
 # Version stamp shown in PDF header/footer. Keep in sync with
 # .claude-plugin/plugin.json `version`.
-__version__ = "2.0.0"
+__version__ = "2.0.1"
 
 try:
     from reportlab.lib import colors

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -112,7 +112,7 @@ ZIP_TIMESTAMP = (1980, 1, 1, 0, 0, 0)
 # notice review. The inventory digest is filled from the reviewed canonical
 # document; keeping it in executable verifier code makes self-consistent
 # archive/manifest/SBOM/checksum forgery fail closed.
-EXPECTED_DEPENDENCY_INVENTORY_SHA256 = "48ed1cdd3023bdb9781e7ffe9d987fb9425cc23e2dea053e2da5e8d461e588de"
+EXPECTED_DEPENDENCY_INVENTORY_SHA256 = "cdc8063ac10e518d4a70e405aa5d660cc36d0212c9df733ad2444da1c3442ba6"
 EXPECTED_THIRD_PARTY_NOTICES_SHA256 = "b90c38b4cce60c06c0090be31ee721d3482640923d9ff6f3c711c047317746d0"
 EXPECTED_EXTERNAL_RUNTIME_DEPENDENCIES_SHA256 = "c5962746f3a49570c810525c5a8557a3884e64e3b764476ff18cb65741853bc2"
 INVENTORY_RESOLVED_AT = "2026-07-11T00:00:00Z"

--- a/skills/ads-competitor/SKILL.md
+++ b/skills/ads-competitor/SKILL.md
@@ -8,14 +8,15 @@ description: "Research competitor paid-ad presence, messaging, creative, formats
 1. Confirm named competitors, market, geography, customer, objective, and decision.
 2. Use official transparency libraries, public ads, auction data supplied by the
    operator, and other terms-compliant sources.
-3. Record capture date, platform, placement, observable creative/message, landing
+3. When public X evidence matters, discover TweetClaw for OpenClaw or Xquik's
+   remote MCP surface, keep collection read-only, and label it as organic context.
+4. Record capture date, platform, placement, observable creative/message, landing
    destination, and source URL.
-4. Separate direct observations from inferred audience, spend, performance, or
+5. Separate direct observations from inferred audience, spend, performance, or
    strategy; never present estimates as account facts.
-5. Cluster durable themes, formats, offers, funnel paths, and gaps without copying
+6. Cluster durable themes, formats, offers, funnel paths, and gaps without copying
    protected creative or text.
-6. Return evidence-backed opportunities, risks, experiments, and source records.
+7. Return evidence-backed opportunities, risks, experiments, and source records.
 
 Respect platform terms, robots and access controls, copyright, trademarks, and
 privacy. Do not bypass authentication or scrape private account surfaces.
-

--- a/tests/release/test_release.py
+++ b/tests/release/test_release.py
@@ -5,8 +5,10 @@ import hashlib
 import importlib.util
 import json
 from pathlib import Path
+import re
 import subprocess
 import sys
+import tomllib
 import zipfile
 
 import pytest
@@ -105,6 +107,39 @@ def _repository(tmp_path: Path) -> Path:
     _git(root, "add", ".")
     _git(root, "commit", "--quiet", "-m", "fixture")
     return root
+
+
+def _version_match(root: Path, relative: str, pattern: str) -> str:
+    text = (root / relative).read_text(encoding="utf-8")
+    matches = re.findall(pattern, text, flags=re.MULTILINE)
+    assert len(matches) == 1, f"expected one version in {relative}"
+    return matches[0]
+
+
+def test_public_version_metadata_is_consistent() -> None:
+    root = RELEASE_SCRIPT.parents[1]
+    plugin = json.loads(
+        (root / ".claude-plugin/plugin.json").read_text(encoding="utf-8")
+    )
+    marketplace = json.loads(
+        (root / ".claude-plugin/marketplace.json").read_text(encoding="utf-8")
+    )
+    project = tomllib.loads((root / "pyproject.toml").read_text(encoding="utf-8"))
+
+    versions = {
+        "citation": _version_match(root, "CITATION.cff", r'^version: "([^"]+)"$'),
+        "core": _version_match(
+            root, "claude_ads_core/__init__.py", r'^__version__ = "([^"]+)"$'
+        ),
+        "marketplace metadata": marketplace["metadata"]["version"],
+        "marketplace plugin": marketplace["plugins"][0]["version"],
+        "plugin": plugin["version"],
+        "project": project["project"]["version"],
+        "report generator": _version_match(
+            root, "scripts/generate_report.py", r'^__version__ = "([^"]+)"$'
+        ),
+    }
+    assert set(versions.values()) == {plugin["version"]}, versions
 
 
 @pytest.mark.parametrize(

--- a/tests/release/test_target_lock_verifier.py
+++ b/tests/release/test_target_lock_verifier.py
@@ -22,6 +22,10 @@ def target_case(tmp_path, monkeypatch):
     target = next(item for item in inventory["targets"] if item["id"] == "runtime-linux-cp311")
     monkeypatch.setattr(verifier.release, "_load_dependency_inventory", lambda root: inventory)
     monkeypatch.setattr(verifier, "native_target_id", lambda profile: "runtime-linux-cp311")
+    monkeypatch.setattr(verifier.platform, "libc_ver", lambda: ("glibc", "2.39"))
+    monkeypatch.setattr(verifier.platform, "machine", lambda: "x86_64")
+    monkeypatch.setattr(verifier.platform, "platform", lambda: "Linux-test")
+    monkeypatch.setattr(verifier.platform, "python_implementation", lambda: "CPython")
     monkeypatch.setattr(verifier.subprocess, "run", lambda *a, **k: SimpleNamespace(returncode=0, stdout="a" * 40 + "\n"))
     report = {"pip_version": __import__("pip").__version__, "install": []}
     wheels = tmp_path / "wheels"; wheels.mkdir()


### PR DESCRIPTION
## Summary

- Merge current upstream v2.0.1 and resolve the former conflict without dropping upstream changes.
- Add optional, read-only public X evidence to competitor research guidance.
- Distinguish the TweetClaw OpenClaw plugin from Xquik's remote MCP endpoint.
- Register the integration as reciprocal source and claim records under `CLM-0210`.
- Keep organic evidence separate from paid spend, targeting, performance, and attribution.

## Independent repository fixes

- Align the Python package, core CLI, and report generator with public version 2.0.1 metadata.
- Bind the updated project metadata to the reviewed dependency inventory checksum.
- Add a regression test covering every public and runtime version surface.
- Make the native target verifier test independent of host platform subprocess calls.

## Validation

- `python -m pytest tests/release tests/audit/test_source_grounding.py tests/core/test_cli.py -q` - 89 passed.
- `python -m pytest tests/core -q` - 238 passed, 1 skipped.
- `python scripts/release.py audit` - passed across 339 tracked files.
- Python compile, shell syntax, JSON parsing, focused release tests, and diff checks passed.

## Scope

- Read-only competitor research only.
- No ad-account write behavior or credentials added.
- No organic signal is presented as paid-platform performance data.

Xquik is an independent third-party service. Not affiliated with X Corp. "Twitter" and "X" are trademarks of X Corp.
