### PR TITLE
fix(tests): scope subprocess.run patch to git in target-lock fixture

### DIFF
--- a/tests/release/test_target_lock_verifier.py
+++ b/tests/release/test_target_lock_verifier.py
@@ -22,7 +22,14 @@ def target_case(tmp_path, monkeypatch):
     target = next(item for item in inventory["targets"] if item["id"] == "runtime-linux-cp311")
     monkeypatch.setattr(verifier.release, "_load_dependency_inventory", lambda root: inventory)
     monkeypatch.setattr(verifier, "native_target_id", lambda profile: "runtime-linux-cp311")
-    monkeypatch.setattr(verifier.subprocess, "run", lambda *a, **k: SimpleNamespace(returncode=0, stdout="a" * 40 + "\n"))
+    # verifier.subprocess is the shared stdlib module, so an unconditional patch
+    # also hijacks subprocess.check_output -> platform.platform() on macOS.
+    _real_run = verifier.subprocess.run
+    def _fake_run(*a, **k):
+        if a and list(a[0])[:1] == ["git"]:
+            return SimpleNamespace(returncode=0, stdout="a" * 40 + "\n")
+        return _real_run(*a, **k)
+    monkeypatch.setattr(verifier.subprocess, "run", _fake_run)
     report = {"pip_version": __import__("pip").__version__, "install": []}
     wheels = tmp_path / "wheels"; wheels.mkdir()
     expected_hashes = {}


### PR DESCRIPTION
## Summary

`tests/release/test_target_lock_verifier.py` fails on macOS with an error that
has nothing to do with the code under test:

```
AttributeError: 'str' object has no attribute 'decode'
  .../platform.py:680: in _syscmd_file
    return output.decode('latin-1')
```

The `target_case` fixture patches `verifier.subprocess.run` unconditionally.
`verifier.subprocess` is the shared stdlib module object, so the patch also
hijacks `subprocess.check_output`, which calls `run()` internally.

`verify()` then calls `platform.platform()`. On macOS that falls through to the
generic branch and calls `architecture(sys.executable)` → `_syscmd_file()` →
`check_output()`, which receives the fixture's `str` stdout where bytes are
expected. Linux takes the `elif system == 'Linux'` branch and never calls
`architecture()`, which is why CI stays green.

The fix scopes the fake to `git` invocations and delegates everything else to
the real `subprocess.run`. The fixture still returns the deterministic commit
SHA the assertions depend on, so no assertion changed.

## Type of Change

- [x] Bug fix
- [ ] New sub-skill or feature
- [ ] Reference file update (benchmarks, specs, audit checks)
- [ ] Documentation
- [ ] Other (describe):

## Verification

macOS 15.5, Apple Silicon, CPython 3.12.13, `requirements.lock` +
`requirements-dev.lock` installed with `--require-hashes`:

| Check | Before | After |
| --- | --- | --- |
| `pytest -q tests/release/test_target_lock_verifier.py` | 1 failed | 3 passed |
| `pytest -q` (full suite) | 1 failed, 501 passed, 27 skipped | 502 passed, 27 skipped |
| `python scripts/release.py audit` | passed (339 tracked files) | passed (339 tracked files) |

No regression test is added: the defect is in the fixture itself, and the
existing test is the regression case — it fails before this change and passes
after, on any host where `platform.platform()` shells out.

Note for the full suite on macOS: the WeasyPrint PDF smoke test additionally
needs Homebrew Pango plus `DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/lib`,
otherwise `pytest.importorskip("weasyprint")` raises `OSError` instead of
skipping. That is a separate issue and is not touched here.

## Checklist

- [x] Tested against a sample ad account (if applicable) — n/a, test-only change
- [x] SKILL.md files are under 500 lines — unchanged
- [x] Reference files are under 200 lines — unchanged
- [x] Python scripts output valid JSON — unchanged
- [x] Shell scripts use `set -euo pipefail` — unchanged
- [x] No credentials or API keys in the diff

## Related Issues

None found — searched open issues and PRs for an existing report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)