### PR TITLE
fix(tests): scope target_lock_verifier subprocess stub to git rev-parse

### DIFF
--- a/tests/release/test_target_lock_verifier.py
+++ b/tests/release/test_target_lock_verifier.py
@@ -22,7 +22,10 @@ def target_case(tmp_path, monkeypatch):
     target = next(item for item in inventory["targets"] if item["id"] == "runtime-linux-cp311")
     monkeypatch.setattr(verifier.release, "_load_dependency_inventory", lambda root: inventory)
     monkeypatch.setattr(verifier, "native_target_id", lambda profile: "runtime-linux-cp311")
-    monkeypatch.setattr(verifier.subprocess, "run", lambda *a, **k: SimpleNamespace(returncode=0, stdout="a" * 40 + "\n"))
+    # Stub only `git rev-parse`; delegate the rest, since subprocess.check_output
+    # is built on run() and platform.platform() shells out on some hosts.
+    real_run = verifier.subprocess.run
+    monkeypatch.setattr(verifier.subprocess, "run", lambda cmd, *a, **k: SimpleNamespace(returncode=0, stdout="a" * 40 + "\n") if list(cmd[:2]) == ["git", "rev-parse"] else real_run(cmd, *a, **k))
     report = {"pip_version": __import__("pip").__version__, "install": []}
     wheels = tmp_path / "wheels"; wheels.mkdir()
     expected_hashes = {}


### PR DESCRIPTION
## Problem

`tests/release/test_target_lock_verifier.py::test_valid_native_report_writes_commit_lock_inventory_resolver_and_runner_bindings` fails on macOS. It cannot pass there as written.

The `target_case` fixture replaces `subprocess.run` wholesale:

```python
monkeypatch.setattr(verifier.subprocess, "run", lambda *a, **k: SimpleNamespace(returncode=0, stdout="a" * 40 + "\n"))
```

`verifier.subprocess` is the stdlib `subprocess` module, so this patch is process-wide, and `subprocess.check_output` is implemented on top of `run()`. Any stdlib call that shells out during the test therefore receives the stub's `str` where it expects `bytes`.

`verify()` records `platform.platform()` in its environment block (`scripts/verify_target_lock.py:107`). On macOS that routes through `platform.architecture()` → `_syscmd_file` → `subprocess.check_output`, which then calls `.decode()` on the stub's `str`:

```
E   AttributeError: 'str' object has no attribute 'decode'
/.../python3.12/platform.py:680: AttributeError
```

On Linux `platform.platform()` reads `uname` and never shells out, so CI is green and the failure only reaches contributors developing on macOS.

Isolating which calls break under the patch:

```
python_implementation: ok
platform:              AttributeError: 'str' object has no attribute 'decode'   <- line 107
machine:               ok
libc_ver:              ok
architecture:          AttributeError: 'str' object has no attribute 'decode'
```

## Change

Stub only the `git rev-parse` invocation the fixture actually needs; delegate every other call to the real `subprocess.run`.

## Verification

macOS 15 (arm64), CPython 3.12.13, deps from `requirements.lock` + `requirements-dev.lock`:

- `tests/release/test_target_lock_verifier.py` — 1 failed, 6 passed → **7 passed**
- Full suite — **506 passed, 23 skipped, 0 failed**
- `python scripts/release.py audit` — passed (339 tracked files)

No behavior change to `scripts/verify_target_lock.py`; the assertion on `source_commit == "a" * 40` still exercises the stubbed git path.

## Note

Running the suite on a clean macOS checkout also needs `pip` present in the venv — `tests/release/test_target_lock_verifier.py:26` reads `__import__("pip").__version__`, and `uv venv` does not install `pip` by default. That is arguably a separate issue; happy to file or fold in a `pytest.importorskip("pip")` if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)