### PR TITLE
fix: fail landing analysis without grading empty results

### DIFF
--- a/scripts/analyze_landing.py
+++ b/scripts/analyze_landing.py
@@ -296,6 +296,8 @@ def analyze_landing(
 
 def grade_landing(result: dict) -> dict:
     """Grade landing page quality based on ad audit criteria."""
+    if result.get("error"):
+        return {}
     grades = {}
 
     # G59: Mobile speed (LCP)
@@ -370,6 +372,13 @@ def main():
     )
     grades = grade_landing(result)
 
+    if result["error"]:
+        if args.json:
+            print(json.dumps({**result, "grades": grades}, indent=2))
+        else:
+            print(f"Error: {result['error']}", file=sys.stderr)
+        raise SystemExit(1)
+
     if args.json:
         output = {**result, "grades": grades}
         print(json.dumps(output, indent=2))
@@ -403,9 +412,6 @@ def main():
         print(f"\nAudit Grades:")
         for check, grade in grades.items():
             print(f"  [{grade}] {check}")
-
-        if result["error"]:
-            print(f"\nError: {result['error']}")
 
 
 if __name__ == "__main__":

--- a/tests/scripts/test_analyze_landing.py
+++ b/tests/scripts/test_analyze_landing.py
@@ -1,0 +1,55 @@
+"""Landing analysis failures must not be reported as completed audits."""
+
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[2] / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+pytest.importorskip("playwright.sync_api")
+import analyze_landing
+
+
+@pytest.mark.parametrize("json_output", [False, True])
+def test_cli_exits_nonzero_without_grades_when_analysis_is_blocked(json_output):
+    command = [sys.executable, str(SCRIPTS_DIR / "analyze_landing.py"), "https://example.com"]
+    if json_output:
+        command.append("--json")
+    result = subprocess.run(command, capture_output=True, text=True, timeout=15)
+
+    assert result.returncode == 1
+    if json_output:
+        output = json.loads(result.stdout)
+        assert "egress-sandbox attestation" in output["error"]
+        assert output["grades"] == {}
+    else:
+        assert "egress-sandbox attestation" in result.stderr
+        assert result.stdout == ""
+
+
+@pytest.mark.parametrize("error", ["Page load timed out", "Browser closed"])
+def test_failed_analysis_is_not_graded(error):
+    assert analyze_landing.grade_landing({"error": error}) == {}
+
+
+def test_successful_analysis_is_still_graded():
+    result = {
+        "error": None,
+        "performance": {"lcp_ms": 2000},
+        "content": {"h1": "Example"},
+        "schema": {"product_schema": True},
+        "conversion": {"cta_above_fold": True, "form_present": False},
+        "mobile": {"viewport_meta": True, "horizontal_scroll": False},
+    }
+
+    assert analyze_landing.grade_landing(result) == {
+        "G59_mobile_speed": "PASS",
+        "G60_relevance": "PASS",
+        "G61_schema": "PASS",
+        "cta_above_fold": "PASS",
+        "mobile_responsive": "PASS",
+    }


### PR DESCRIPTION
## Summary

When landing analysis returns an error, the CLI currently grades the empty metrics and exits successfully. This can make an inaccessible page appear to have completed an audit with failing checks.

Return no grades for failed analysis, exit with status 1, and print the error to stderr in text mode. JSON mode retains the analysis fields and an empty `grades` object. Successful grading is unchanged.

## Type of Change

- [x] Bug fix

## Validation

- Five regression tests pass, covering both CLI output modes, timeout/browser errors, and successful grading. Four failed before the fix.
- `python scripts/release.py audit` passes.
- Full suite in an isolated Python 3.13 environment on Windows: 509 passed, 11 skipped, 8 failed, 6 fixture errors. Running the affected existing test files on unchanged base `669c760` reproduces all eight failures and six errors. These involve existing Windows path/symlink assumptions, PDF runtime requirements, and the target-lock fixture already addressed by #58/#59.

## Checklist

- [x] Python scripts output valid JSON in JSON mode
- [x] No credentials or API keys in the diff
- Sample ad account, skills, reference files, and shell scripts: not applicable. Tests exercise the existing egress rejection; browser egress controls are unchanged.

## Related Issues

Closes #61.
