### PR TITLE
chore(deps): reduce Dependabot update noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,14 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
+    groups:
+      actions-minor-patch:
+        patterns:
+          - '*'
+        update-types:
+          - minor
+          - patch
+    open-pull-requests-limit: 2
     labels:
       - dependencies


### PR DESCRIPTION
This reduces routine Dependabot review volume while keeping major updates available for individual review.

Changes:

- `github-actions` in `/`: schedule `weekly` to `monthly`, pull-request limit `default(5)` to `2`, groups `actions-minor-patch`.

Scope is limited to `.github/dependabot.yml`. No security-update group, CODEOWNERS rule, dependency file, or repository setting changes.

Validation:

- The reviewed patch applies exactly to `main` at `ac21644933910419529bcf81efb95a9ca71edf81` and Dependabot blob `f6f3246cb6fb0ea42bdf8db419f4914bbd086739`.
- Duplicate-key-safe YAML validation, policy-field preservation, exact after-file comparison, and `git diff --check` passed.

Automerge is not enabled. Merge remains subject to review and required checks.
